### PR TITLE
Fix SPI bug

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Setup Arduino CLI
-        uses: arduino/setup-arduino-cli@v1.1.1
+        uses: arduino/setup-arduino-cli@v2
 
       - name: Install platform
         run: |

--- a/.github/workflows/platformio_ci.yml
+++ b/.github/workflows/platformio_ci.yml
@@ -19,22 +19,22 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: ${{ runner.os }}-pip-
 
     - name: Cache PlatformIO
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
 
     - name: Install PlatformIO
       run: |

--- a/src/spic-arduino.cpp
+++ b/src/spic-arduino.cpp
@@ -14,7 +14,7 @@
  * This function is setting the basics for a SPIC and the default spi.
  *
  */
-SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
+SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
 {
 	spi = &SPI;
 }
@@ -28,7 +28,7 @@ SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
  * @param mode   SPI mode
  * @param clock  SPI clock divider
  */
-SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
+SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
 {
 	this->lsb = lsb;
 	this->mode = mode;
@@ -48,7 +48,7 @@ SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mod
  * @param mosiPin  mosi pin number
  * @param sckPin   systemclock pin number
  */
-SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
+SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
 {
 	this->csPin = csPin;
 	this->misoPin = misoPin;

--- a/src/spic-arduino.hpp
+++ b/src/spic-arduino.hpp
@@ -26,6 +26,8 @@ using namespace tle94112;
  * @brief Arduino SPIC class
  *
  */
+
+#define SPEED 1000000
 class SPICIno: virtual public SPIC
 {
 	private:


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.
This pull request includes updates to the GitHub Actions workflows and changes to the `SPICIno` class in the `src/spic-arduino.cpp` and `src/spic-arduino.hpp` files. The most important changes include updating the versions of GitHub Actions used and modifying the `SPICIno` class to use a new `SPEED` constant.

### GitHub Actions Updates:
* [`.github/workflows/build-check.yml`](diffhunk://#diff-e667cbf8e98c5f2339128886eb5203cc3e3cfc6452374cdf97af98c92b2485efL31-R31): Updated `arduino/setup-arduino-cli` action from version `v1.1.1` to `v2`.
* [`.github/workflows/platformio_ci.yml`](diffhunk://#diff-8137dcf55be5fc94882948120fb8b4efb6b434daa38fa0bc3abebb4c9eaa9384L22-R37): Updated `actions/checkout` to version `v4`, `actions/cache` to version `v4`, and `actions/setup-python` to version `v5`.

### `SPICIno` Class Modifications:
* [`src/spic-arduino.cpp`](diffhunk://#diff-50692562caa4ac88cd3c9d856fab5988840be531773f05434f98feca197f3341L17-R17): Changed the `clock` parameter in `SPICIno` constructors to use the new `SPEED` constant instead of `ARDUINO_SPI_CLOCK`. [[1]](diffhunk://#diff-50692562caa4ac88cd3c9d856fab5988840be531773f05434f98feca197f3341L17-R17) [[2]](diffhunk://#diff-50692562caa4ac88cd3c9d856fab5988840be531773f05434f98feca197f3341L31-R31) [[3]](diffhunk://#diff-50692562caa4ac88cd3c9d856fab5988840be531773f05434f98feca197f3341L51-R51)
* [`src/spic-arduino.hpp`](diffhunk://#diff-34406be91fbaa2383e51ba497de93f7a3c716d634ad28be441d1ea85111a2f20R29-R30): Defined a new constant `SPEED` with a value of `1000000`.

