### PR TITLE
Feature/direct register access

### DIFF
--- a/examples/directRegisterControl/directRegisterControl.ino
+++ b/examples/directRegisterControl/directRegisterControl.ino
@@ -1,0 +1,108 @@
+/*!
+ * \name        directRegisterControl
+ * \author      Infineon Technologies AG
+ * \copyright   2025 Infineon Technologies AG
+ * \brief       This example demonstrates how to control two motors via direct register setting
+ * \details
+ * If motors are connected to the TLE94112 on certain half bridges, than they can be controlled via direct register
+ * setting which reduces greatly the overhead and allows fast motor controlling.
+ * therefore the half bridges HB1 to HB4, HB5 to HB8 and HB9 to HB12 must be used together, either for controlling
+ * two motors on one tuple (0.9 A), or one motor on one tuple (1.8 A).
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+ #include <tle94112-ino.hpp>
+
+ //! Tle94112 Object
+ Tle94112Ino controller = Tle94112Ino();
+ 
+ //! Tle94112 registers for motor 1 and 2
+ uint8_t motor[2][2] = {
+   {REG_ACT_1, REG_PWM_DC_1},
+   {REG_ACT_3, REG_PWM_DC_3}
+ };
+ 
+ //! Tle94112 register for motor direction
+ volatile uint8_t oldDirection [] = { LL_HH, HH_LL };
+ 
+ /**
+  * @brief Changes the motor direction and speed
+  * The motor direction is set by the change of the High/Low switching of the motor half bridges in one register.
+  * This needs some time to change the direction, so its avoided if not needed.
+  * Setting the speed is done by setting the PWM register.
+  *
+  * @param motorNum uint8_t motor number (0 or 1)
+  * @param dir uint8_t direction (HH_LL or LL_HH for forward/backward of one motor on four half bridges)
+  * @param speed uint8_t speed (0-255)
+  * @param errorCheck bool if true, the error register is cleared after setting the speed
+  */
+ void motorSet(uint8_t motorNum, uint8_t dir, uint8_t speed, bool errorCheck = false)
+ {
+   if (dir != oldDirection[motorNum]) {
+     controller.directWriteReg(motor[motorNum][0], dir);
+     oldDirection[motorNum] = dir;
+   }
+   controller.directWriteReg(motor[motorNum][1], speed);
+   if (errorCheck) {
+     controller.clearErrors();
+   }
+ }
+ 
+ 
+ //! connect motor between halfbridge 1 and halfbridge 2
+ void setup()
+ {
+ 
+   Serial.begin(9600);
+   while (!Serial) {
+     ; // wait for serial port to connect. Needed for native USB port only
+   }
+   Serial.println("TLE94112 Motor Speed Control Example");
+   delay(1000);
+ 
+   // Enable MotorController Tle94112
+   // Note: Required to be done before starting to configure the motor
+   controller.begin();
+ 
+   // four half bridges and two PWM channels are used to control two motors
+   controller.configHB(controller.TLE_HB1, controller.TLE_HIGH, controller.TLE_PWM1);
+   controller.configHB(controller.TLE_HB2, controller.TLE_HIGH, controller.TLE_PWM1);
+   controller.configHB(controller.TLE_HB3, controller.TLE_LOW,  controller.TLE_NOPWM);
+   controller.configHB(controller.TLE_HB4, controller.TLE_LOW,  controller.TLE_NOPWM);
+ 
+   controller.configHB(controller.TLE_HB9,  controller.TLE_HIGH, controller.TLE_PWM3);
+   controller.configHB(controller.TLE_HB10, controller.TLE_HIGH, controller.TLE_PWM3);
+   controller.configHB(controller.TLE_HB11, controller.TLE_LOW,  controller.TLE_NOPWM);
+   controller.configHB(controller.TLE_HB12, controller.TLE_LOW,  controller.TLE_NOPWM);
+ 
+   // all stop
+   controller.configPWM(controller.TLE_PWM1, controller.TLE_FREQ200HZ, 0);
+   controller.configPWM(controller.TLE_PWM3, controller.TLE_FREQ200HZ, 0);
+   controller.clearErrors();
+ 
+   delay(1000);
+ 
+ }
+ 
+ 
+ void loop() {
+   controller.clearErrors();
+ 
+   Serial.println("forward / backward");
+   motorSet(0, HH_LL, 100);
+   motorSet(1, LL_HH, 100);
+   delay(1000);
+ 
+   Serial.println(" speed up / down");
+   motorSet(0, HH_LL, 255);
+   motorSet(1, LL_HH, 50);
+   delay(1000);
+ 
+   Serial.print("backward / forward ");
+   motorSet(0, LL_HH, 255);
+   motorSet(1, HH_LL, 255);
+   delay(1000);
+ 
+ }

--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
       "url":"https://www.infineon.com/cms/en/product/power/motor-control-ics/brushed-dc-motor-driver-ics/multi-half-bridge-ics/",
       "maintainer": true
    },
-   "version":"4.1.1",
+   "version":"4.2.0",
    "license":"MIT",
    "frameworks":"arduino",
    "platforms":[  

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=multi-half-bridge
-version=4.1.1
+version=4.2.0
 author=Infineon Technologies
 maintainer=Infineon Technologies <www.infineon.com>
 sentence=Library of Infineon Multi Half-Bridge IC controllers family

--- a/src/tle94112-ino.cpp
+++ b/src/tle94112-ino.cpp
@@ -25,13 +25,27 @@ Tle94112Ino::Tle94112Ino(void):Tle94112()
 }
 
 /**
- * @brief constructor with individual pin assignment
+ * @brief constructor with individual pin assignment for CS pin
  *
- * @param csPin  pin number of the CS pin
+ * @param csPin  pin number of the CS (chip select) pin
  */
 Tle94112Ino::Tle94112Ino(uint8_t csPin):Tle94112()
 {
 	Tle94112::en = new GPIOIno( TLE94112_PIN_EN, OUTPUT, GPIOIno::POSITIVE );
+	Tle94112::cs = new GPIOIno( csPin, OUTPUT, GPIOIno::POSITIVE );
+	Tle94112::timer = new TimerIno();
+	Tle94112::sBus = new SPICIno();
+}
+
+/**
+ * @brief constructor with individual pin assignment for CS and EN pin.
+ *
+ * @param csPin  pin number of the CS (chip select) pin
+ * @param enPin  pin number of the EN (enable) pin
+ */
+Tle94112Ino::Tle94112Ino(uint8_t csPin, uint8_t enPin):Tle94112()
+{
+	Tle94112::en = new GPIOIno( enPin, OUTPUT, GPIOIno::POSITIVE );
 	Tle94112::cs = new GPIOIno( csPin, OUTPUT, GPIOIno::POSITIVE );
 	Tle94112::timer = new TimerIno();
 	Tle94112::sBus = new SPICIno();

--- a/src/tle94112-ino.hpp
+++ b/src/tle94112-ino.hpp
@@ -26,6 +26,7 @@ class Tle94112Ino: virtual public Tle94112
 	public:
 		Tle94112Ino(void);
 		Tle94112Ino(uint8_t csPin);
+		Tle94112Ino(uint8_t csPin, uint8_t enPin);
 };
 /** @} */
 

--- a/src/tle94112-types.hpp
+++ b/src/tle94112-types.hpp
@@ -30,6 +30,40 @@ namespace tle94112
         READ_ERROR  = -3,    /**< Read error */
         WRITE_ERROR = -4,    /**< Write error */
     };
+
+    #define REG_ACT_1               0x03
+    #define REG_ACT_2               0x43
+    #define REG_ACT_3               0x23
+
+    #define REG_MODE_1              0x63
+    #define REG_MODE_2              0x13
+    #define REG_MODE_3              0x53
+
+    #define REG_PWM_CH_FREQ         0x33
+
+    #define REG_PWM_DC_1            0x73
+    #define REG_PWM_DC_2            0x0B
+    #define REG_PWM_DC_3            0x4B
+
+    #define REG_SYS_DIAG            0x1B
+    #define REG_ERR1                0x5B
+    #define REG_ERR2                0x3B
+    #define REG_ERR3                0x7B
+    #define REG_ERR4                0x07
+    #define REG_ERR5                0x47
+    #define REG_ERR6                0x27
+
+    #define REG_FW_OL               0x2B
+    #define REG_FW_CTRL             0x6B
+
+    #define HL_HL                   0b10011001
+    #define HL_LH                   0b10010110
+    #define LH_HL                   0b01101001
+    #define LH_LH                   0b01100110
+
+    #define HH_LL                   0b10100101
+    #define LL_HH                   0b01011010
+
     /** @} */
 
     /** @} */

--- a/src/tle94112.cpp
+++ b/src/tle94112.cpp
@@ -301,6 +301,21 @@ void Tle94112::init(void)
 /*! \brief time in milliseconds to wait for chipselect signal raised */
 #define TLE94112_CS_RISETIME        2
 
+void Tle94112::directWriteReg(uint8_t reg, uint8_t data)
+{
+	TLE94112_LOG_MSG(__FUNCTION__);
+	
+	uint8_t address = reg | TLE94112_CMD_WRITE;
+	uint8_t byte0;
+	uint8_t byte1;
+
+	cs->disable();
+	sBus->transfer(address, byte0);
+	sBus->transfer(data, byte1);
+	cs->enable();
+	timer->delayMilli(TLE94112_CS_RISETIME);
+}
+
 void Tle94112::writeReg(uint8_t reg, uint8_t mask, uint8_t shift, uint8_t data)
 {
 	uint8_t address = mCtrlRegAddresses[reg];

--- a/src/tle94112.hpp
+++ b/src/tle94112.hpp
@@ -227,6 +227,28 @@ class Tle94112
 		//! \brief clears all clearable error flags
 		void clearErrors();
 
+		/*! \brief writes data bits directly to a register of the TLE94112
+		 *
+		 * \param reg   address of the register to be written to.
+		 * \param data  the data byte that has to be written.
+		 *
+		 * \see mCtrlRegAddresses
+		 * \see mCtrlRegData
+		 */
+		void directWriteReg(uint8_t reg, uint8_t data);
+
+		/*! \brief reads one byte from a status register of the TLE94112
+		 *
+		 * \param reg status register number(mapping array index / StatusRegisters constant) of the register
+		 *
+		 * \return data byte that has been read
+		 *
+		 * \see StatusRegisters
+		 * \see TLE94112_NUM_STATUS_REGS
+		 * \see mStatusRegAddresses
+		 */
+		uint8_t readStatusReg(uint8_t reg);
+
 		SPIC     *sBus;      //<! \brief SPI cover class as representation of the SPI bus
 		GPIOC    *cs;        //<! \brief shield enable GPIO to switch chipselect on/off
 		GPIOC    *en;        //<! \brief shield enable GPIO to switch shield on/off
@@ -362,18 +384,6 @@ class Tle94112
 		 * \see mCtrlRegData
 		 */
 		void writeReg(uint8_t reg, uint8_t mask, uint8_t shift, uint8_t data);
-
-		/*! \brief reads one byte from a status register of the TLE94112
-		 *
-		 * \param reg status register number(mapping array index / StatusRegisters constant) of the register
-		 *
-		 * \return data byte that has been read
-		 *
-		 * \see StatusRegisters
-		 * \see TLE94112_NUM_STATUS_REGS
-		 * \see mStatusRegAddresses
-		 */
-		uint8_t readStatusReg(uint8_t reg);
 
 		/*! \brief reads some bits from a status register of the TLE94112
 		 *


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

## Description
This pull request introduces a new example for motor control, updates the library version, and adds enhancements to the `Tle94112` library. The most significant changes include the addition of a new example demonstrating direct register control for motors, the introduction of new constructors and methods for the `Tle94112` class, and the definition of additional register constants. These changes aim to improve functionality and flexibility for motor control applications.

### New Example for Motor Control:
* Added a new example file `examples/directRegisterControl/directRegisterControl.ino` demonstrating how to control two motors via direct register settings. It includes motor direction and speed control functions, setup configurations, and a loop for motor operation.

### Enhancements to the `Tle94112` Library:
* Added a new constructor in `Tle94112Ino` to support individual pin assignment for both CS (chip select) and EN (enable) pins. [[1]](diffhunk://#diff-933c62a52d58f11c86be8bd6faca708c06c887f975f1b8cea21af8ba625f10d6R39-R52) [[2]](diffhunk://#diff-c831eb4de13c06822c3b19d1b56da5187d1252b98a07ee9f35b2ed7fb9f21d86R29)
* Introduced a `directWriteReg` method in the `Tle94112` class for directly writing data to a specific register, enabling more efficient motor control. [[1]](diffhunk://#diff-3d05b0b7fa1034267f47721d5b79aceb39e218397ded34bca103967b05a804c8R304-R318) [[2]](diffhunk://#diff-f5da8ff0e27cd735cfcc57764d90eb88b430744bcaeb564a9a026f2c27c70e4fR230-R251)
* Defined additional register constants (e.g., `REG_ACT_1`, `REG_PWM_DC_1`, `HH_LL`, `LL_HH`) in `src/tle94112-types.hpp` to facilitate direct register operations.

### Version Updates:
* Updated the library version from `4.1.1` to `4.2.0` in both `library.json` and `library.properties` to reflect the new features and improvements. [[1]](diffhunk://#diff-64cc7cdde6789dc1c1c4a6f406cd1ff6a6a00027097788e2d52fc27b0d75502eL15-R15) [[2]](diffhunk://#diff-f267f9ae2f5d5d56a1dbb305e95d40d4408d9ee7f71357f1f67fb18c29b7f082L2-R2)

### Documentation Improvements:
* Updated the documentation for the `Tle94112Ino` constructors to clarify the purpose of the CS and EN pins.

## Related Issue
1. Relatively slow switching of half bridges leads to due to multiple SPI transfers can be an issue in some applications -> Register can now be written directly.
2. Enable pin needs to be set in library -> can now be set in constructor.