### PR TITLE
Desmakers 4585

### DIFF
--- a/examples/directRegisterControl/directRegisterControl.ino
+++ b/examples/directRegisterControl/directRegisterControl.ino
@@ -100,7 +100,7 @@
    motorSet(1, LL_HH, 50);
    delay(1000);
  
-   Serial.print("backward / forward ");
+   Serial.println("backward / forward ");
    motorSet(0, LL_HH, 255);
    motorSet(1, HH_LL, 255);
    delay(1000);

--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
       "url":"https://www.infineon.com/cms/en/product/power/motor-control-ics/brushed-dc-motor-driver-ics/multi-half-bridge-ics/",
       "maintainer": true
    },
-   "version":"4.2.0",
+   "version":"4.2.1",
    "license":"MIT",
    "frameworks":"arduino",
    "platforms":[  

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=multi-half-bridge
-version=4.2.0
+version=4.2.1
 author=Infineon Technologies
 maintainer=Infineon Technologies <www.infineon.com>
 sentence=Library of Infineon Multi Half-Bridge IC controllers family

--- a/src/spic-arduino.cpp
+++ b/src/spic-arduino.cpp
@@ -73,7 +73,7 @@ Error_t SPICIno::init()
 /**
  * @brief Deinitialize the SPIC
  *
- * This function deinitializes the chosen spi channel.
+ * This function deinitialize the chosen spi channel.
  *
  * @return      Error_t
  */

--- a/src/spic-arduino.cpp
+++ b/src/spic-arduino.cpp
@@ -73,7 +73,7 @@ Error_t SPICIno::init()
 /**
  * @brief Deinitialize the SPIC
  *
- * This function deinitialize the chosen spi channel.
+ * This function deinitializes the chosen spi channel.
  *
  * @return      Error_t
  */

--- a/src/spic-arduino.cpp
+++ b/src/spic-arduino.cpp
@@ -14,7 +14,7 @@
  * This function is setting the basics for a SPIC and the default spi.
  *
  */
-SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
+SPICIno::SPICIno(): clock(SPEED)
 {
 	spi = &SPI;
 }
@@ -28,10 +28,8 @@ SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
  * @param mode   SPI mode
  * @param clock  SPI clock divider
  */
-SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
+SPICIno::SPICIno(uint32_t clock): clock(SPEED)
 {
-	this->lsb = lsb;
-	this->mode = mode;
 	this->clock = clock;
 	spi = &SPI;
 }
@@ -48,7 +46,7 @@ SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mod
  * @param mosiPin  mosi pin number
  * @param sckPin   systemclock pin number
  */
-SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
+SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin): clock(SPEED)
 {
 	this->csPin = csPin;
 	this->misoPin = misoPin;
@@ -68,14 +66,14 @@ SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin
 Error_t SPICIno::init()
 {
 	spi->begin();
-	spi->beginTransaction(SPISettings(SPEED, this->lsb, this->mode));
+	spi->beginTransaction(SPISettings(SPEED, LSBFIRST, SPI_MODE1));
 	return OK;
 }
 
 /**
  * @brief Deinitialize the SPIC
  *
- * This function is deinitializing the chosen spi channel.
+ * This function deinitialize the chosen spi channel.
  *
  * @return      Error_t
  */

--- a/src/spic-arduino.hpp
+++ b/src/spic-arduino.hpp
@@ -36,13 +36,11 @@ class SPICIno: virtual public SPIC
 		uint8_t     mosiPin;
 		uint8_t     sckPin;
 		SPIClass    *spi;
-		uint8_t     lsb;
-		uint8_t     mode;
 		uint32_t    clock;
 
 	public:
 					SPICIno();
-					SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock);
+					SPICIno(uint32_t clock);
 					SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin=MISO, uint8_t mosiPin=MOSI, uint8_t sckPin=SCK);
 					~SPICIno();
 		Error_t     init();

--- a/src/tle94112-platf-ino.hpp
+++ b/src/tle94112-platf-ino.hpp
@@ -26,7 +26,7 @@
 /*!
  * Standard chip select pin for first TLE94112 shield
  */
-#define TLE94112_PIN_CS1     10
+#define TLE94112_PIN_CS1     SS
 
 /*!
  * Standard chip select pin for second TLE94112 shield

--- a/src/tle94112.cpp
+++ b/src/tle94112.cpp
@@ -23,7 +23,7 @@ using namespace tle94112;
 #define TLE94112_CS_RISETIME        2
 
 /*! \brief micro rise time to wait for chipselect signal raised */
-#define TLE94112_CS_MICRO_RISETIME  250
+#define TLE94112_CS_MICRO_RISETIME  150
 
 
 Tle94112::Tle94112(void)
@@ -333,7 +333,7 @@ uint8_t Tle94112::readStatusReg(uint8_t reg, uint8_t mask, uint8_t shift)
 	sBus->transfer(address,byte0);
 	sBus->transfer(0xFF,received);
 	cs->enable();
-	timer->delayMilli(TLE94112_CS_RISETIME);
+	timer->delayMicro(TLE94112_CS_MICRO_RISETIME);
 
 	received = (received & mask) >> shift;
 
@@ -353,5 +353,5 @@ void Tle94112::clearStatusReg(uint8_t reg)
 	sBus->transfer(address,byte0);
 	sBus->transfer(0,byte1);
 	cs->enable();
-	timer->delayMilli(TLE94112_CS_RISETIME);
+	timer->delayMicro(TLE94112_CS_MICRO_RISETIME);
 }

--- a/src/tle94112.cpp
+++ b/src/tle94112.cpp
@@ -114,20 +114,9 @@ void Tle94112::_configHB(uint8_t hb, uint8_t state, uint8_t pwm, uint8_t activeF
 
     TLE94112_LOG_MSG(__FUNCTION__);
 
-	uint8_t reg = mHalfBridges[hb].stateReg;
-	uint8_t mask = mHalfBridges[hb].stateMask;
-	uint8_t shift = mHalfBridges[hb].stateShift;
-	writeReg(reg, mask, shift, state);
-
-	reg = mHalfBridges[hb].pwmReg;
-	mask = mHalfBridges[hb].pwmMask;
-	shift = mHalfBridges[hb].pwmShift;
-	writeReg(reg, mask, shift, pwm);
-
-	reg = mHalfBridges[hb].fwReg;
-	mask = mHalfBridges[hb].fwMask;
-	shift = mHalfBridges[hb].fwShift;
-	writeReg(reg, mask, shift, activeFW);
+	writeReg(mHalfBridges[hb].stateReg, mHalfBridges[hb].stateMask, mHalfBridges[hb].stateShift, state);
+	writeReg(mHalfBridges[hb].pwmReg,   mHalfBridges[hb].pwmMask,   mHalfBridges[hb].pwmShift,   pwm);
+	writeReg(mHalfBridges[hb].fwReg,    mHalfBridges[hb].fwMask,    mHalfBridges[hb].fwShift,    activeFW);
 }
 
 void Tle94112::configPWM(PWMChannel pwm, PWMFreq freq, uint8_t dutyCycle)
@@ -140,15 +129,8 @@ void Tle94112::_configPWM(uint8_t pwm, uint8_t freq, uint8_t dutyCycle)
 
     TLE94112_LOG_MSG(__FUNCTION__);
 
-	uint8_t reg = mPwmChannels[pwm].freqReg;
-	uint8_t mask = mPwmChannels[pwm].freqMask;
-	uint8_t shift = mPwmChannels[pwm].freqShift;
-	writeReg(reg, mask, shift, freq);
-
-	reg = mPwmChannels[pwm].dcReg;
-	mask = mPwmChannels[pwm].dcMask;
-	shift = mPwmChannels[pwm].dcShift;
-	writeReg(reg, mask, shift, dutyCycle);
+	writeReg(mPwmChannels[pwm].freqReg, mPwmChannels[pwm].freqMask, mPwmChannels[pwm].freqShift, freq);
+	writeReg(mPwmChannels[pwm].dcReg,   mPwmChannels[pwm].dcMask,   mPwmChannels[pwm].dcShift,   dutyCycle);
 }
 
 uint8_t Tle94112::setLedMode(HalfBridge hb, uint8_t active)
@@ -196,10 +178,7 @@ uint8_t Tle94112::_getHBOverCurrent(uint8_t hb)
 {
     TLE94112_LOG_MSG(__FUNCTION__);
 
-	uint8_t reg = mHalfBridges[hb].ocReg;
-	uint8_t mask = mHalfBridges[hb].ocMask;
-	uint8_t shift = mHalfBridges[hb].ocShift;
-	return readStatusReg(reg, mask, shift);
+	return readStatusReg(mHalfBridges[hb].ocReg, mHalfBridges[hb].ocMask, mHalfBridges[hb].ocShift);
 }
 
 uint8_t Tle94112::getHBOpenLoad(HalfBridge hb)
@@ -211,10 +190,7 @@ uint8_t Tle94112::_getHBOpenLoad(uint8_t hb)
 {
 	TLE94112_LOG_MSG(__FUNCTION__);
 
-	uint8_t reg = mHalfBridges[hb].olReg;
-	uint8_t mask = mHalfBridges[hb].olMask;
-	uint8_t shift = mHalfBridges[hb].olShift;
-	return readStatusReg(reg, mask, shift);
+	return readStatusReg(mHalfBridges[hb].olReg, mHalfBridges[hb].olMask, mHalfBridges[hb].olShift);
 }
 
 void Tle94112::clearErrors()
@@ -235,39 +211,39 @@ void Tle94112::init(void)
     TLE94112_LOG_MSG(__FUNCTION__);
 
 	//!< initial control register configuration
-	mCtrlRegAddresses[static_cast<int>(Tle94112::HB_ACT_1_CTRL)] = 0x03;
+	mCtrlRegAddresses[HB_ACT_1_CTRL]    = REG_ACT_1;
+	mCtrlRegAddresses[HB_ACT_2_CTRL]    = REG_ACT_2;
+	mCtrlRegAddresses[HB_ACT_3_CTRL]    = REG_ACT_3;
+	mCtrlRegAddresses[HB_MODE_1_CTRL]   = REG_MODE_1;
+	mCtrlRegAddresses[HB_MODE_2_CTRL]   = REG_MODE_2;
+	mCtrlRegAddresses[HB_MODE_3_CTRL]   = REG_MODE_3;
+	mCtrlRegAddresses[PWM_CH_FREQ_CTRL] = REG_PWM_CH_FREQ;
+	mCtrlRegAddresses[PWM1_DC_CTRL]     = REG_PWM_DC_1;
+	mCtrlRegAddresses[PWM2_DC_CTRL]     = REG_PWM_DC_2;
+	mCtrlRegAddresses[PWM3_DC_CTRL]     = REG_PWM_DC_3;
+	mCtrlRegAddresses[FW_OL_CTRL]       = REG_FW_OL;
+	mCtrlRegAddresses[FW_CTRL]          = REG_FW_CTRL;
 	mCtrlRegData[HB_ACT_1_CTRL]         = 0;
-	mCtrlRegAddresses[HB_ACT_2_CTRL]    = 0x43;
 	mCtrlRegData[HB_ACT_2_CTRL]         = 0;
-	mCtrlRegAddresses[HB_ACT_3_CTRL]    = 0x23;
 	mCtrlRegData[HB_ACT_3_CTRL]         = 0;
-	mCtrlRegAddresses[HB_MODE_1_CTRL]   = 0x63;
 	mCtrlRegData[HB_MODE_1_CTRL]        = 0;
-	mCtrlRegAddresses[HB_MODE_2_CTRL]   = 0x13;
 	mCtrlRegData[HB_MODE_2_CTRL]        = 0;
-	mCtrlRegAddresses[HB_MODE_3_CTRL]   = 0x53;
 	mCtrlRegData[HB_MODE_3_CTRL]        = 0;
-	mCtrlRegAddresses[PWM_CH_FREQ_CTRL] = 0x33;
 	mCtrlRegData[PWM_CH_FREQ_CTRL]      = 0;
-	mCtrlRegAddresses[PWM1_DC_CTRL]     = 0x73;
 	mCtrlRegData[PWM1_DC_CTRL]          = 0;
-	mCtrlRegAddresses[PWM2_DC_CTRL]     = 0x0B;
 	mCtrlRegData[PWM2_DC_CTRL]          = 0;
-	mCtrlRegAddresses[PWM3_DC_CTRL]     = 0x4B;
 	mCtrlRegData[PWM3_DC_CTRL]          = 0;
-	mCtrlRegAddresses[FW_OL_CTRL]       = 0x2B;
 	mCtrlRegData[FW_OL_CTRL]            = 0;
-	mCtrlRegAddresses[FW_CTRL]          = 0x6B;
 	mCtrlRegData[FW_CTRL]               = 0;
 
 	//!< status register configuration
-	mStatusRegAddresses[SYS_DIAG1]       = 0x1B;
-	mStatusRegAddresses[OP_ERROR_1_STAT] = 0x5B;
-	mStatusRegAddresses[OP_ERROR_2_STAT] = 0x3B;
-	mStatusRegAddresses[OP_ERROR_3_STAT] = 0x7B;
-	mStatusRegAddresses[OP_ERROR_4_STAT] = 0x07;
-	mStatusRegAddresses[OP_ERROR_5_STAT] = 0x47;
-	mStatusRegAddresses[OP_ERROR_6_STAT] = 0x27;
+	mStatusRegAddresses[SYS_DIAG1]       = REG_SYS_DIAG;
+	mStatusRegAddresses[OP_ERROR_1_STAT] = REG_ERR1;
+	mStatusRegAddresses[OP_ERROR_2_STAT] = REG_ERR2;
+	mStatusRegAddresses[OP_ERROR_3_STAT] = REG_ERR3;
+	mStatusRegAddresses[OP_ERROR_4_STAT] = REG_ERR4;
+	mStatusRegAddresses[OP_ERROR_5_STAT] = REG_ERR5;
+	mStatusRegAddresses[OP_ERROR_6_STAT] = REG_ERR6;
 
 	//!< bit masking for all halfbridges
 	mHalfBridges[TLE_NOHB] = { HB_ACT_1_CTRL, 0x00, 0, HB_MODE_1_CTRL, 0x00, 0, FW_OL_CTRL, 0x00, 0, OP_ERROR_1_STAT, 0x00, 0, OP_ERROR_4_STAT, 0x00, 0 };

--- a/src/tle94112.cpp
+++ b/src/tle94112.cpp
@@ -13,7 +13,18 @@
 
 using namespace tle94112;
 
+/*! \brief SPI address commands */
+#define TLE94112_CMD_WRITE          0x80;
+#define TLE94112_CMD_CLEAR          0x80;
+
 #define TLE94112_STATUS_INV_MASK    (Tle94112::TLE_POWER_ON_RESET)
+
+/*! \brief time in milliseconds to wait for chipselect signal raised */
+#define TLE94112_CS_RISETIME        2
+
+/*! \brief micro rise time to wait for chipselect signal raised */
+#define TLE94112_CS_MICRO_RISETIME  250
+
 
 Tle94112::Tle94112(void)
 {
@@ -268,14 +279,6 @@ void Tle94112::init(void)
 
 }
 
-/*! \brief SPI address commands */
-#define TLE94112_CMD_WRITE          0x80;
-#define TLE94112_CMD_CLEAR          0x80;
-
-#define TLE94112_STATUS_INV_MASK    (Tle94112::TLE_POWER_ON_RESET)
-
-/*! \brief time in milliseconds to wait for chipselect signal raised */
-#define TLE94112_CS_RISETIME        2
 
 void Tle94112::directWriteReg(uint8_t reg, uint8_t data)
 {
@@ -289,7 +292,7 @@ void Tle94112::directWriteReg(uint8_t reg, uint8_t data)
 	sBus->transfer(address, byte0);
 	sBus->transfer(data, byte1);
 	cs->enable();
-	timer->delayMilli(TLE94112_CS_RISETIME);
+	timer->delayMicro(TLE94112_CS_MICRO_RISETIME);
 }
 
 void Tle94112::writeReg(uint8_t reg, uint8_t mask, uint8_t shift, uint8_t data)


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
This pull request introduces significant changes to the `SPICIno` and `Tle94112` classes, simplifying their constructors, improving code readability, and enhancing maintainability. The key updates include removing unused parameters in `SPICIno` constructors, refactoring repeated code patterns in `Tle94112`, and replacing hard coded register addresses with named constants for clarity.

### Simplification of `SPICIno` constructors:
* Removed unused `lsb` and `mode` parameters from all constructors in `SPICIno`, as they were no longer needed. (`src/spic-arduino.cpp`, `src/spic-arduino.hpp`) [[1]](diffhunk://#diff-50692562caa4ac88cd3c9d856fab5988840be531773f05434f98feca197f3341L17-R17) [[2]](diffhunk://#diff-50692562caa4ac88cd3c9d856fab5988840be531773f05434f98feca197f3341L31-L34) [[3]](diffhunk://#diff-50692562caa4ac88cd3c9d856fab5988840be531773f05434f98feca197f3341L51-R49) [[4]](diffhunk://#diff-50692562caa4ac88cd3c9d856fab5988840be531773f05434f98feca197f3341L71-R76) [[5]](diffhunk://#diff-34406be91fbaa2383e51ba497de93f7a3c716d634ad28be441d1ea85111a2f20L39-R43)

### Refactoring in `Tle94112` class:
* Consolidated repeated `writeReg` and `readStatusReg` calls by directly passing structure members, reducing redundancy and improving readability. (`src/tle94112.cpp`) [[1]](diffhunk://#diff-3d05b0b7fa1034267f47721d5b79aceb39e218397ded34bca103967b05a804c8L117-R119) [[2]](diffhunk://#diff-3d05b0b7fa1034267f47721d5b79aceb39e218397ded34bca103967b05a804c8L143-R133) [[3]](diffhunk://#diff-3d05b0b7fa1034267f47721d5b79aceb39e218397ded34bca103967b05a804c8L199-R181) [[4]](diffhunk://#diff-3d05b0b7fa1034267f47721d5b79aceb39e218397ded34bca103967b05a804c8L214-R193)
* Replaced hardcoded register addresses with descriptive constants (e.g., `REG_ACT_1`, `REG_ERR1`) for better maintainability and readability in initialization logic. (`src/tle94112.cpp`)

### Minor updates:
* Updated the `TLE94112_PIN_CS1` macro to use the `SS` constant instead of a hard coded value for better compatibility and flexibility. (`src/tle94112-platf-ino.hpp`)
